### PR TITLE
remove "code" and "code token" profiles from rp-id_token-bad-c_hash

### DIFF
--- a/test_tool/cp/test_rplib/rp/flows/rp-id_token-bad-c_hash.json
+++ b/test_tool/cp/test_rplib/rp/flows/rp-id_token-bad-c_hash.json
@@ -8,9 +8,7 @@
   "claims": "normal",
   "capabilities": {
     "response_types_supported": [
-      "code",
       "code id_token",
-      "code token",
       "code id_token token"
     ]
   },


### PR DESCRIPTION
remove (optional) flows that don't return an id_token in the
frontchannel; the test server would not return a (bad) c_hash in these
flows anyway

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>