### PR TITLE
add assertion errors to AsyncAuthn as well

### DIFF
--- a/test_tool/cp/test_op/flows/OP-prompt-none-NotLoggedIn.json
+++ b/test_tool/cp/test_op/flows/OP-prompt-none-NotLoggedIn.json
@@ -19,7 +19,10 @@
       "AsyncAuthn": {
         "set_expect_error": {
           "error": [
-            "login_required"
+            "login_required",
+	        "interaction_required",
+    	    "session_selection_required",
+        	"consent_required"
           ],
           "stop": false
         },


### PR DESCRIPTION
add the acceptable error messages from the assertion to the expected
error messages for AsyncAuthn otherwise the response test will be
aborted before reaching the assertion