### PR TITLE
improve description for rp-id_token-kid-absent-single-jwks

### DIFF
--- a/test_tool/cp/test_rplib/rp/flows/rp-id_token-kid-absent-single-jwks.json
+++ b/test_tool/cp/test_rplib/rp/flows/rp-id_token-kid-absent-single-jwks.json
@@ -23,7 +23,7 @@
       "RS256"
     ]
   },
-  "short_description": "Accepts ID Token without 'kid' claim in JOSE header if only one JWK supplied in 'jwks_uri'",
-  "detailed_description": "Request an ID token and verify its signature using the keys provided by the Issuer.",
-  "expected_result": "Use the single key published by the Issuer to verify the ID Tokens signature and accept the ID Token after doing ${ID_TOKEN_VALIDATION}."
+  "short_description": "Accepts ID Token without 'kid' claim in JOSE header if only one matching JWK is supplied in 'jwks_uri'",
+  "detailed_description": "Request an ID token and verify its signature using a single matching key provided by the Issuer.",
+  "expected_result": "Use the single matching key out of the Issuer's published set to verify the ID Tokens signature and accept the ID Token after doing ${ID_TOKEN_VALIDATION}."
 }


### PR DESCRIPTION
addresses openid-certification/oidctest#29

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>