### PR TITLE
fix pyoidc to 0.10.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "requests >= 2.0.0",
         'future',
         'CherryPy == 8.9.1',
-        'oic >= 0.10.0',
+        'oic == 0.10.0',
         'otest >= 0.7.0',
         'psutil',
         'cherrypy-cors >= 1.5',


### PR DESCRIPTION
until phone_number_verified claim type checking is fixed

see: https://github.com/OpenIDC/pyoidc/issues/407

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>