### PR TITLE
don't require `auth_time` in id_token for `OP-prompt-login`

### DIFF
--- a/src/oidctest/op/check.py
+++ b/src/oidctest/op/check.py
@@ -1071,6 +1071,9 @@ class MultipleSignOn(Error):
         # verify that it is in fact two separate authentications
         try:
             assert idt[0]["auth_time"] != idt[1]["auth_time"]
+        except KeyError:
+            self._message = "No \"auth_time\" found in both ID tokens so it cannot be compared"
+            self._status = WARNING            
         except AssertionError:
             self._message = "Not two separate authentications!"
             try:


### PR DESCRIPTION
OP-prompt-login shouldn't depend on "auth_time" since it is not a
required claim. Do issue a warning. See: openid-certification/oidctest#36