### PR TITLE
display "dev" for the version in the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ addons:
 before_install:
   - git clone https://github.com/openid-certification/oidctest.git
   - cd oidctest
+  - git checkout stable-release-1.0.x
   - docker-compose -f docker/docker-compose.yml up -d
   - cd -
 

--- a/test_tool/cp/test_op/version.py
+++ b/test_tool/cp/test_op/version.py
@@ -1,1 +1,1 @@
-VERSION = '2.0.0'
+VERSION = '2.0.x-dev'

--- a/test_tool/cp/test_rplib/rp/version.py
+++ b/test_tool/cp/test_rplib/rp/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.0.0'
+VERSION = '1.0.x-dev'


### PR DESCRIPTION
- so new-op/new-rp will no longer display the release numbers
2.0.0/1.0.0
- also make testers use the stable branch for the Dockerized version of
the suite

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>