### PR TITLE
add 3rd-party-init-sso test

### DIFF
--- a/src/oidctest/cp/op.py
+++ b/src/oidctest/cp/op.py
@@ -484,3 +484,82 @@ class Provider(Root):
                         return self.configuration
 
         return self
+
+
+class RelyingPartyInstance(object):
+    
+    def rp_3rd_party_init_login(self, op, client_id):
+        if client_id in op.cdb:
+            if 'initiate_login_uri' in op.cdb[client_id]:
+                raise cherrypy.HTTPRedirect(op.cdb[client_id]['initiate_login_uri'])
+            else:
+                response = ['<pre>']
+                response.append("no 3rd-party initiated login URI found for  " + client_id)
+                response.append('</pre>')
+                return '\n'.join(response)
+        else:
+            raise cherrypy.HTTPError(404, "client_id " + client_id + " not found in client database!")            
+ 
+    @cherrypy.expose
+    @cherrypy_cors.tools.expose_public()
+    @cherrypy.tools.allow(
+        methods=["GET", "OPTIONS"])
+    def index(self, op, test_id, client_id):
+        if cherrypy.request.method == "OPTIONS":
+            logger.debug('Request headers: {}'.format(cherrypy.request.headers))
+            cherrypy_cors.preflight(
+                allowed_methods=["GET"],
+                allowed_headers=['Authorization', 'content-type'],
+                allow_credentials=True, origins='*'
+            )
+        else:
+            if test_id == "rp-3rd_party-init-login":
+                return self.rp_3rd_party_init_login(op, client_id)
+            raise cherrypy.HTTPError(404, "no test handler found for test id: " + test_id)
+
+class RelyingParty(object):
+    def __init__(self, op_handler, version=''):
+        self.version = version
+        self.op_handler = op_handler
+        self.instance = RelyingPartyInstance()
+
+    @cherrypy.expose
+    def index(self):
+        response = [
+            HTML_PRE,
+            '<div class="jumbotron">',
+            '  <p>',
+            '    Add the Relying Party instance identifier to the path....',
+            '  </p>',
+            '</div>',
+
+            HTML_FOOTER.format(self.version),
+
+            HTML_POST
+        ]
+        return '\n'.join(response)
+
+    def _cp_dispatch(self, vpath):
+        # Only get here if vpath != None
+        ent = cherrypy.request.remote.ip
+        logger.info('ent:{}, vpath: {}'.format(ent, vpath))
+        
+        if len(vpath) >= 1:
+            ev = init_events(cherrypy.request.path_info,
+                             'Test tool version:{}'.format(self.version))
+            # e.g https://rp_test:8080/rp/mod_auth_openidc/rp-3rd_party-init-login/OLtakKrycmtj
+            rp_id = vpath.pop(0)
+            test_id = vpath.pop(0)
+            client_id = vpath.pop(0)
+
+            endpoint = ''            
+                    
+            op = self.op_handler.get(rp_id, test_id, ev,
+                                     endpoint)[0]
+            cherrypy.request.params['op'] = op
+            cherrypy.request.params['test_id'] = test_id
+            cherrypy.request.params['client_id'] = client_id
+            
+            return self.instance            
+        else:
+            raise cherrypy.HTTPError(400, 'Unknown vpath stuffy')

--- a/src/oidctest/rp/provider.py
+++ b/src/oidctest/rp/provider.py
@@ -326,6 +326,12 @@ class Provider(provider.Provider):
                 error="invalid_configuration_parameter",
                 descr="Invalid redirect_uri: {}".format(err))
 
+        if "initiate_login_uri" in self.behavior_type:
+            if not "initiate_login_uri" in reg_req:
+                return error(
+                    error="invalid_configuration_parameter",
+                    descr="No \"initiate_login_uri\" endpoint found in the Client Registration Request\"")
+
         # Do initial verification that all endpoints from the client uses
         #  https
         for endp in ["jwks_uri", "initiate_login_uri"]:

--- a/test_tool/cp/test_rplib/rp/config.py
+++ b/test_tool/cp/test_rplib/rp/config.py
@@ -35,7 +35,8 @@ GRPS = [
     "Response Type and Response Mode", "claims Request Parameter",
     "request_uri Request Parameter", "scope Request Parameter",
     "nonce Request Parameter", "Client Authentication",
-    "ID Token", "Key Rotation", "Claims Types", "UserInfo Endpoint"
+    "ID Token", "Key Rotation", "Claims Types", "UserInfo Endpoint",
+    "3rd-Party Init SSO"
 ]
 
 # Only Username and password.

--- a/test_tool/cp/test_rplib/rp/example_conf.py
+++ b/test_tool/cp/test_rplib/rp/example_conf.py
@@ -33,7 +33,8 @@ GRPS = [
     "Response Type and Response Mode", "claims Request Parameter",
     "request_uri Request Parameter", "scope Request Parameter",
     "nonce Request Parameter", "Client Authentication",
-    "ID Token", "Key Rotation", "Claims Types", "UserInfo Endpoint"
+    "ID Token", "Key Rotation", "Claims Types", "UserInfo Endpoint",
+    "3rd-Party Init SSO"
 ]
 
 #Only Username and password.

--- a/test_tool/cp/test_rplib/rp/flows/rp-3rd_party-init-login.json
+++ b/test_tool/cp/test_rplib/rp/flows/rp-3rd_party-init-login.json
@@ -1,0 +1,18 @@
+{
+  "group": "3rd-Party Init SSO",
+  "claims": "normal",
+  "behavior": [ "initiate_login_uri" ],
+  "capabilities": {
+    "response_types_supported": [
+      "code",
+      "id_token",
+      "id_token token",
+      "code id_token",
+      "code token",
+      "code id_token token"
+    ]
+  },
+  "short_description": "Supports initiation of the SSO flow from a 3rd-party.",
+  "detailed_description": "Exposes a ${THIRD_PARTY_INITIATED_LOGIN} endpoint that 3rd parties can use to start the SSO process. Initiated via: https://<rp_test_host>:<rp_test_port>/rp/<rp_id>/rp-3rd_party-init-login/<client_id>",
+  "expected_result": "A successful Authentication Request to the OP triggered by accessing the ${THIRD_PARTY_INITIATED_LOGIN} URL."
+}

--- a/test_tool/cp/test_rplib/rp/server.py
+++ b/test_tool/cp/test_rplib/rp/server.py
@@ -15,6 +15,7 @@ from oidctest.cp.log_handler import Log
 from oidctest.cp.log_handler import Tar
 from oidctest.cp.op import Provider
 from oidctest.cp.op import WebFinger
+from oidctest.cp.op import RelyingParty
 from oidctest.cp.op_handler import OPHandler
 from oidctest.cp.setup import cb_setup
 from oidctest.cp.test_list import TestList
@@ -119,6 +120,8 @@ if __name__ == '__main__':
     cherrypy.tree.mount(ClearLog(folder), '/clear')
     cherrypy.tree.mount(Tar(folder), '/mktar')
 
+    cherrypy.tree.mount(RelyingParty(op_handler, version=_version), '/rp')
+    
     # OIDC Providers
     cherrypy.tree.mount(Provider(op_handler, _flows, version=_version),
                         '/', provider_config)


### PR DESCRIPTION
no GUI, triggered by calling:
https://<rp_test_host>:<rp_test_port>/rp/<rp_id>/rp-3rd_party-init-login/<client_id>
for a registered client/rp instance

@rohe: please review; this should also setup basic handling for adding additional tests in the future with a GUI displayed for a specific rp_id and/or client_id and/or test_id