### PR TITLE
require e-mail address for RP testers at registration time

### DIFF
--- a/src/oidctest/rp/provider.py
+++ b/src/oidctest/rp/provider.py
@@ -342,6 +342,15 @@ class Provider(provider.Provider):
                         error="invalid_configuration_parameter",
                         descr="Non-HTTPS endpoint in '{}'".format(endp))
 
+        if not "contacts" in reg_req:
+            return error(
+                error="invalid_configuration_parameter",
+                descr="No \"contacts\" claim provided in registration request.")
+        elif not "@" in reg_req["contacts"][0]:
+            return error(
+                error="invalid_configuration_parameter",
+                descr="First address in \"contacts\" value in registration request is not a valid e-mail address.")
+
         _response = provider.Provider.registration_endpoint(self, request,
                                                             authn, **kwargs)
         self.events.store(EV_HTTP_RESPONSE, _response)


### PR DESCRIPTION
addresses the 2nd half of openid-certification/oidctest#26

caveat emptor: this change may break some automation tools that don't provide this information (yet)... oh well