### PR TITLE
avoid sending null values in dynamic client registration

### DIFF
--- a/test_tool/cp/test_op/flows/OIDC/OP-Rotation-RP-Enc.json
+++ b/test_tool/cp/test_op/flows/OIDC/OP-Rotation-RP-Enc.json
@@ -15,8 +15,7 @@
       "Registration": {
         "set_request_args": {
           "userinfo_encrypted_response_enc": "A128CBC-HS256",
-          "userinfo_encrypted_response_alg": "RSA1_5",
-          "userinfo_signed_response_alg": null
+          "userinfo_encrypted_response_alg": "RSA1_5"
         },
         "check_support": {
           "WARNING": {

--- a/test_tool/cp/test_op/flows/OIDC/OP-UserInfo-Enc.json
+++ b/test_tool/cp/test_op/flows/OIDC/OP-UserInfo-Enc.json
@@ -15,8 +15,7 @@
       "Registration": {
         "set_request_args": {
           "userinfo_encrypted_response_enc": "A128CBC-HS256",
-          "userinfo_encrypted_response_alg": "RSA1_5",
-          "userinfo_signed_response_alg": null
+          "userinfo_encrypted_response_alg": "RSA1_5"
         },
         "check_support": {
           "ERROR": {

--- a/test_tool/cp/test_op/flows/OIDC/OP-request_uri-Enc.json
+++ b/test_tool/cp/test_op/flows/OIDC/OP-request_uri-Enc.json
@@ -15,8 +15,7 @@
       "Registration": {
         "set_request_args": {
           "request_object_encryption_alg": "RSA1_5",
-          "request_object_encryption_enc": "A128CBC-HS256",
-          "request_object_signing_alg": null
+          "request_object_encryption_enc": "A128CBC-HS256"
         },
         "check_support": {
           "WARNING": {

--- a/test_tool/cp/test_op/flows/OIDC/OP-request_uri-Unsigned.json
+++ b/test_tool/cp/test_op/flows/OIDC/OP-request_uri-Unsigned.json
@@ -14,7 +14,7 @@
     {
       "Registration": {
         "set_request_args": {
-          "request_object_signing_alg": null
+          "request_object_signing_alg": "none"
         },
         "check_support": {
           "ERROR": {

--- a/test_tool/cp/test_op/flows/OP-Rotation-RP-Enc.json
+++ b/test_tool/cp/test_op/flows/OP-Rotation-RP-Enc.json
@@ -15,8 +15,7 @@
       "Registration": {
         "set_request_args": {
           "userinfo_encrypted_response_enc": "A128CBC-HS256",
-          "userinfo_encrypted_response_alg": "RSA1_5",
-          "userinfo_signed_response_alg": null
+          "userinfo_encrypted_response_alg": "RSA1_5"
         },
         "check_support": {
           "WARNING": {

--- a/test_tool/cp/test_op/flows/OP-UserInfo-Enc.json
+++ b/test_tool/cp/test_op/flows/OP-UserInfo-Enc.json
@@ -15,8 +15,7 @@
       "Registration": {
         "set_request_args": {
           "userinfo_encrypted_response_enc": "A128CBC-HS256",
-          "userinfo_encrypted_response_alg": "RSA1_5",
-          "userinfo_signed_response_alg": null
+          "userinfo_encrypted_response_alg": "RSA1_5"
         },
         "check_support": {
           "ERROR": {

--- a/test_tool/cp/test_op/flows/OP-request-Unsigned.json
+++ b/test_tool/cp/test_op/flows/OP-request-Unsigned.json
@@ -14,7 +14,7 @@
     {
       "Registration": {
         "set_request_args": {
-          "request_object_signing_alg": null
+          "request_object_signing_alg": "none"
         },
         "check_support": {
           "WARNING": {

--- a/test_tool/cp/test_op/flows/OP-request_uri-Enc.json
+++ b/test_tool/cp/test_op/flows/OP-request_uri-Enc.json
@@ -15,8 +15,7 @@
       "Registration": {
         "set_request_args": {
           "request_object_encryption_alg": "RSA1_5",
-          "request_object_encryption_enc": "A128CBC-HS256",
-          "request_object_signing_alg": null
+          "request_object_encryption_enc": "A128CBC-HS256"
         },
         "check_support": {
           "WARNING": {


### PR DESCRIPTION
see openid-certification/oidctest#69

- for OP-request-Unsigned set request_object_signing_alg to "none" (as
in #67)
- for OP-request_uri-Enc remove request_object_signing_alg from the
registration request
- for OP-UserInfo-Enc and OP-Rotation-RP-Enc remove
userinfo_signed_response_alg from the registration request

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>