### PR TITLE
use unreleased pyoidc; add OP-response-form_post to form_post profile

### DIFF
--- a/docker/op_test/Dockerfile
+++ b/docker/op_test/Dockerfile
@@ -15,10 +15,10 @@ WORKDIR ${SRCDIR}
 #
 # TEMPORARY
 #
+#ENV PYOIDC_VERSION=tags/v0.12.0
+ENV PYOIDC_VERSION=5a958a13eb9c5a3606818af4d23441f111f227b1
 RUN git clone https://github.com/OpenIDC/pyoidc.git
-RUN cd pyoidc && git fetch origin && git checkout tags/v0.12.0 -b temp-patch
-COPY docker/op_test/pyoidc.patch pyoidc.patch
-RUN cd pyoidc && patch -p1 < ../pyoidc.patch
+RUN cd pyoidc && git fetch origin && git checkout ${PYOIDC_VERSION} -b temp
 RUN cd pyoidc &&  python3 setup.py install
 #
 # TEMPORARY

--- a/test_tool/cp/test_op/flows/OP-Response-form_post.json
+++ b/test_tool/cp/test_op/flows/OP-Response-form_post.json
@@ -24,6 +24,7 @@
     }
   ],
   "usage": {
+    "form_post": true,
     "extra": true,
     "return_type": [
       "C", "I", "IT","CI", "CT", "CIT"


### PR DESCRIPTION
support for form_post profile was added in otest 0.7.3/master; add
OP-response-form_post to that profile

use pyoidc master commit checkout to support:
- return RegistrationError on missing required attribute; see:
openid-certification/oidctest#70
- allow endpoints to have query parts; see
openid-certification/oidctest#74
- log the registration request, see openid-certification/oidctest#38
- audience is endpoint dependent; see openid-certification/oidctest#21

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>