### PR TITLE
OP-Response-form_post no longer needs to be extra

### DIFF
--- a/test_tool/cp/test_op/flows/OP-Response-form_post.json
+++ b/test_tool/cp/test_op/flows/OP-Response-form_post.json
@@ -25,7 +25,6 @@
   ],
   "usage": {
     "form_post": true,
-    "extra": true,
     "return_type": [
       "C", "I", "IT","CI", "CT", "CIT"
     ]


### PR DESCRIPTION
since it is in its own form_post profile now

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>