### PR TITLE
make form_post response mode available in all response types

### DIFF
--- a/test_tool/cp/test_rplib/rp/flows/rp-response_mode-form_post.json
+++ b/test_tool/cp/test_rplib/rp/flows/rp-response_mode-form_post.json
@@ -3,6 +3,7 @@
   "claims": "normal",
   "capabilities": {
     "response_types_supported": [
+      "code",
       "id_token",
       "id_token token",
       "code id_token",


### PR DESCRIPTION
add it to the "code" response type as well; see
openid-certification/oidctest#100

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>