### PR TITLE
update maintenance documentation and upgrade CI OP version

### DIFF
--- a/docker/op/Dockerfile
+++ b/docker/op/Dockerfile
@@ -12,7 +12,7 @@ ENV SUBDIR ${SRCDIR}/${INSTDIR}
 
 WORKDIR ${SRCDIR}
 
-ENV VERSION_NODE_OP   tags/v3.0.1
+ENV VERSION_NODE_OP   tags/v4.0.3
 
 RUN git clone https://github.com/panva/node-oidc-provider.git
 RUN cd node-oidc-provider && git checkout ${VERSION_NODE_OP} && cd -

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,108 +1,344 @@
 # Operational Maintenance
 
-*Version 1.1.0 - July 31, 2017*
+*Version 2.0.0 - June 20, 2018*
 
 This document describes operational maintenance procedures for the OpenID Connect OP and RP certification environments
 that the OpenID Foundation provides. It lists important directory/file structures and the steps one would have to take
 to update the code, documentation and/or configuration of these environments.
 
-For regular maintanance go directly to the [Deployment](#deployment) section.
+For regular maintenance go directly to the [Deployment](#deployment) section.
+
+### Environments
+
+There are 2 environments, one for production and one for testing. Each environment contains 2 servers, one that runs the OP test
+suite and one that runs the RP test suite. All 4 servers are virtual machines running on Amazon EC2 accessible via:
+[https://console.aws.amazon.com](https://console.aws.amazon.com).
+- OP test suite production server:  
+  [op.certification.openid.net](https://op.certification.openid.net:60000)
+- RP test suite production server:  
+ [`p.certification.openid.net](https://rp.certification.openid.net:8080)
+- OP test suite test/development server:  
+  [new-op.certification.openid.net](https://new-op.certification.openid.net:60000)
+- RP test suite test/development server:  
+  [new-rp.certification.openid.net](https://new-rp.certification.openid.net:8080)
 
 ### SSH Login
 
 Make sure you have an account on the machine that is allowed to execute `sudo` commands. Login to the server with:
-````shell
+
+```shell
 ssh <username>@[op|rp].certification.openid.net
-````
+ssh <username>@[new-op|new-rp].certification.openid.net
+```
 
 ### Directories/Files Layout
 The directories and files that are important for the OP and RP test environment.
 
 Main source directory:
-````
+
+```
 /usr/local/src
-````
+```
 
 Dependencies are in the sub directories:
-````
+
+```
 otest
 oidctest
-````
+```
 
-For the OP there's also a custom `pyoidc` directory checked out that contains a patched release 0.12.0.
+There are other dependencies like `pyoidc` and `pyjwkest` that are automatically installed.
 
 ### Installation
 
 NB: not needed on OP/RP machine itself anymore.
 
-See also the Docker instructions in the files in the "docker" subdirectory for a step-by-step walk-through
-for a new installation from scratch.
+See also the Docker instructions in the files in the "docker" sub directory for a step-by-step walk-through
+for a new installation from scratch. **The docker file is leading for how one deploys a new environment.** It
+is also made available for those who want to run a local test suite instance which they can integrate into
+their OP/RP development/testing/continuous integration environment.
 
 Install:
-````
+
+```
 cd /usr/local
 oidc_setup /usr/local/src/oidctest oidf
 copy/edit config.py and tt_config.py into oidc_op
-````
+```
 
 Migrate existing OP test instances:
-````
+
+```
 copy entities into oidc_op
 copy assigned_ports.json into oidc_op
-````
+```
 
 ### Certificates
 The certificates for the test instances are configured in the configuration files, `config.py` and `conf.py` for the OP and RP respectively
 and set to the following paths:
-````
+
+```
 SERVER_CERT = "/usr/local/oidf/certs/op.certification.openid.net-Public.crt" 
 SERVER_KEY = "/usr/local/oidf/certs/openid.key" 
 CERT_CHAIN = "/usr/local/oidf/certs/op.certification.openid.net-Intermediate.crt"
 CA_BUNDLE = "/usr/local/oidf/certs/op.certification.openid.net-Intermediate.crt"
-````
-Note that when these certificates are rolled over, the test instances need to be restarted to pickup the new certs.
-The Apache webserver that serves the default landing page on port 443 also points to these certificates so make sure
-the names are retained and the apache server is also restarted when the certificates are rolled over with:
-````
+```
+
+Note that when these certificates are rolled over, the test instances need to be restarted to pickup the new certificates.
+The Apache web server that serves the default landing page on port 443 also points to these certificates so make sure
+the names are retained and the Apache server is also restarted when the certificates are rolled over with:
+
+```
 sudo service apache2 restart
-````
+```
+
+### Release Management
+
+##### Overview
+
+- merge/rebase upstream repositories for rohe/oidctest and rohe/otest into openid-certification/oidctest and openid-certification/otest
+- wait for CI on oidctest/master to finish succesfully, possibly also change openid-certification/oidc-provider-conformance tests and openid-certification/openid-client-conformance-tests based on upstream changes
+- merge oidctest/master into oidctest/stable-release-1.1.x and adapt version numbers and changelog
+  test_tool/cp/test_op/version.py and test_tool/cp/test_rplib/rp/version.py
+- deploy on rp/op according to the steps in the docker/op_test and docker/rp_test files
+
+##### Notes
+- pull requests for oidctest and otest go via the upstream repositories in the rohe organization
+- review the commits in the upstream repositories so we know what to expect...
+- manage versions of `oidctest`, `otest` and all of its dependencies, most notably `pyoidc`
+- official oidctest and otest are living in the openid-certification organization, upstream repositories are in the rohe organization
+- try to do releases only with official versions of oidctest, otest and pyoidc; as an exeception it may be necessary to checkout a specific commit version of pyoidc
+- branches in openid-certification/oidctest: `master` and `stable-release-1.1.x`
+- Docker files in `stable-release-1.1.x` are leading
+- oidctest version number 1.x.x relates to a OP 2.x.x version and an RP 1.x.x version: upgrading OP (or RP) would increase
+  the oidctest version/tag number but not necessarily lead to a new RP (resp. OP) release!
+- otest -> release
+- oidctest -> merge-prepare-commit and then adapt version numbers
+
+#### Prerequisites
+
+Local git setup.
+
+##### otest
+
+```
+$ cd ~/projects/otest && git remote -v
+origin	https://github.com/zmartzone/otest.git (fetch)
+origin	https://github.com/zmartzone/otest.git (push)
+stable	https://github.com/openid-certification/otest.git (fetch)
+stable	https://github.com/openid-certification/otest.git (push)
+upstream	https://github.com/rohe/otest.git (fetch)
+upstream	https://github.com/rohe/otest.git (push)
+
+$ cd ~/projects/otest && git branch -v
+* master        52dd5c5 Merge pull request #5 from panva/patch-2
+  stable-master 0abf696 Merge branch 'master' of https://github.com/openid-certification/otest into stable-master
+```
+
+##### oidc-provider-conformance-tests
+
+```
+$ cd ~/projects/oidc-provider-conformance-tests && git remote -v
+origin	https://github.com/zmartzone/oidc-provider-conformance-tests.git (fetch)
+origin	https://github.com/zmartzone/oidc-provider-conformance-tests.git (push)
+stable	https://github.com/openid-certification/oidc-provider-conformance-tests.git (fetch)
+stable	https://github.com/openid-certification/oidc-provider-conformance-tests.git (push)
+upstream	https://github.com/panva/oidc-provider-conformance-tests (fetch)
+upstream	https://github.com/panva/oidc-provider-conformance-tests (push)
+
+$ cd ~/projects/oidc-provider-conformance-tests && git branch -v
+  master        e28a354 allow for local docker testing
+* stable-master e626a2d Merge branch 'master' of https://github.com/openid-certification/oidc-provider-conformance-tests into stable-master
+```
+
+##### openid-client-conformance-tests
+
+```
+$ cd ~/projects/openid-client-conformance-tests && git remote -v
+origin	https://github.com/zmartzone/openid-client-conformance-tests.git (fetch)
+origin	https://github.com/zmartzone/openid-client-conformance-tests.git (push)
+stable	https://github.com/openid-certification/openid-client-conformance-tests.git (fetch)
+stable	https://github.com/openid-certification/openid-client-conformance-tests.git (push)
+upstream	https://github.com/panva/openid-client-conformance-tests.git (fetch)
+upstream	https://github.com/panva/openid-client-conformance-tests.git (push)
+
+$ cd ~/projects/openid-client-conformance-tests && git branch -v
+* master        2e85a25 Update README.md
+  stable-master 2e85a25 Update README.md
+```
+
+##### oidctest
+
+```
+$ cd ~/projects/oidctest && git remote -v
+origin	https://github.com/zmartzone/oidctest.git (fetch)
+origin	https://github.com/zmartzone/oidctest.git (push)
+stable	https://github.com/openid-certification/oidctest.git (fetch)
+stable	https://github.com/openid-certification/oidctest.git (push)
+upstream	https://github.com/rohe/oidctest.git (fetch)
+upstream	https://github.com/rohe/oidctest.git (push)
+
+$ cd ~/projects/oidctest && git branch -v
+* master                             ebebbec Merge pull request #95 from zmartzone/update-dev-version-number-display-on-test
+  stable-master                      ebebbec Merge pull request #95 from zmartzone/update-dev-version-number-display-on-test
+  stable-release-1.0.x               93fa4fb remove obsolete pyoidc patch
+  stable-release-1.1.x               8f84592 release OP 2.1.0 and RP 1.1.0
+```
+
+#### Steps
+
+##### otest
+
+```
+cd ~/projects/otest
+git fetch upstream
+
+git checkout master
+git rebase upstream/master
+git push
+
+git checkout stable-master
+git rebase upstream/master
+git push stable HEAD:master
+```
+
+Possibly release a new otest version if changes were applied from upstream.
+
+```
+vi src/otest/__init__.py
+<edit version number in there>
+git commit -m" tag <version>" .
+git push stable HEAD:master
+```
+
+Release `v<version>` from the master branch in the openid-certification/otest via the web GUI.
+Add release notes by looking at the commits since last release.
+
+
+##### oidc-provider-conformance-tests
+
+```
+cd ~/projects/oidc-provider-conformance-tests
+git fetch upstream
+
+git checkout master
+git merge upstream/master
+git push
+
+git checkout stable-master
+git rebase upstream/master
+git push stable HEAD:master
+```
+
+If needed, release `v<version>` from the master branch in the openid-certification/oidc-provider-conformance-tests via the web GUI.
+Add release notes by looking at the commits since last release.
+
+##### openid-client-conformance-tests
+
+```
+cd ~/projects/openid-client-conformance-tests
+git fetch upstream
+
+git checkout master
+git merge upstream/master
+git push
+
+git checkout stable-master
+git rebase upstream/master
+git push stable HEAD:master
+```
+
+If needed, release `v<version>` from the master branch in the openid-certification/openid-client-conformance-tests via the web GUI.
+Add release notes by looking at the commits since last release.
+
+##### oidctest
+
+```
+cd ~/projects/oidctest
+git fetch upstream
+
+git checkout master
+git rebase upstream/master
+git push
+
+git checkout stable-master
+git merge upstream/master
+git push stable HEAD:master
+```
+
+###### DO WITH MERGE TOOL - MERGE BUT DON'T COMMIT YET - AND UPDATE VERSION NUMBER, UPDATE CHANGELOG, UPDATE DOCKER FILES
+
+```
+git checkout stable-release-1.1.x
+git merge stable-master --no-commit
+
+# document changes compared to last release based on the commit history/diff
+vi ChangeLog
+
+# if a new version of otest was released, change versions of otest in Docker envs
+vi docker/op_test/Dockerfile
+vi docker/rp_test/Dockerfile
+
+# we may also need an update of the OP software node-oidc-provider used in the CI process if a new version was released and it impacts us
+vi docker/op/Dockerfile
+
+# change versions of oidc-provider-conformance-tests and/or openid-client-conformance-tests
+# in the `install:` section
+vi .travis.yml
+
+# if new version of RP suite is required
+vi test_tool/cp/test_op/version.py
+# if new version of RP suite is required
+vi test_tool/cp/test_rplib/rp/version.py
+
+
+# probably do the release commit with an editor/IDE to record changes in commit message (basically copy new ChangeLog entry)
+git commit -m "release v<version" .
+git push
+```
+
+Tag a new release ON THE STABLE-RELEASE branch!! The tag name is not really that important but it binds together OP and RP versions.
 
 ### Deployment
 These are the actual commands one would give to update the code/configuration and make it available in the production environment.
 
 ###### UPDATE
-Pulls down source code, needs deploy after that:
-````	
-cd /usr/local/src
-pullall.sh
-````
+Pulls down source code and deploys after that:
+
+```
+cd /usr/local/src/otest
+sudo git pull
+sudo python3 setup.py install
+
+cd /usr/local/src/oidctest
+sudo git pull
+sudo python3 setup.py install
+```
 
 Note that these commands may result in "You are not currently on a branch" in case specific versions of dependencies are checked out.
 That is probably fine.
 
 ###### DEPLOY
-Deploys code into Python packages:
-````
-cd /usr/local/src
-makeall.sh
-````
 
 Setup OP and RP instances:
-````
+
+```
 cd /usr/local
 sudo oidc_setup.py /usr/local/src/oidctest oidf
-````
+```
 
 Restart RP test instance:
-````
+
+```
 cd /usr/local/oidf/oidc_cp_rplib
-./run.sh
-````
+sudo ./run.sh
+```
 NB: the `run.sh` script will also kill the existing RP test instance
 
 Restart OP test instance:
-````
+
+```
 cd /usr/local/oidf/oidc_op
 sudo ./run.sh
-````
+```
 NB: the `run.sh` script will also kill the existing OP test instance


### PR DESCRIPTION
- add release process steps to maintenance doc
- upgrade CI OP node-oidc-provider from version 3.0.1 to 4.0.3

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>