### PR TITLE
improve rp-response_mode-form_post-error; see #132

### DIFF
--- a/src/oidctest/rp/provider.py
+++ b/src/oidctest/rp/provider.py
@@ -448,8 +448,10 @@ class Provider(provider.Provider):
         if "max_age" in _req and _req["max_age"] == "0" and "prompt" in _req and _req["prompt"] == "none":
             aresp = {
                 "error": "login_required",
-                "state": _req['state']
             }
+            if "state" in _req:
+                aresp['state'] = _req["state"]
+
             return self.response_mode(_req, False,
                                       aresp=aresp,
                                       redirect_uri=_req['redirect_uri'],

--- a/test_tool/cp/test_rplib/rp/flows/rp-response_mode-form_post-error.json
+++ b/test_tool/cp/test_rplib/rp/flows/rp-response_mode-form_post-error.json
@@ -11,7 +11,7 @@
       "code id_token token"
     ]
   },
-  "short_description": "Can consume an authentication response error with response_mode='form_post'",
-  "detailed_description": "Make an authentication request with the ${RESPONSE_MODE} set to ${FORM_POST} and consume the error that is sent in POST parameters.",
-  "expected_result": "HTML form post error response processed, resulting in an error screen shown to the users."
+  "short_description": "Can consume an authentication error response with response_mode='form_post'",
+  "detailed_description": "Construct and send an Authentication Request with ${RESPONSE_MODE} set to ${FORM_POST}, max_age=0 and prompt=none which results in the test suite returning an error because the requested conditions cannot be met.",
+  "expected_result": "The HTML form post authorization error response is consumed, resulting in an error screen shown to the user."
 }


### PR DESCRIPTION
- improve the test description on how to trigger an error
- allow for authentication requests that don't have a `state` parameter
- see openid-certification/oidctest#132

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>