### PR TITLE
fix remote execution security vulnerability

### DIFF
--- a/src/oidctest/app_conf.py
+++ b/src/oidctest/app_conf.py
@@ -10,6 +10,7 @@ import re
 import subprocess
 import sys
 import time
+import shlex
 
 from oic.oic import ProviderConfigurationResponse
 from oic.oic import RegistrationResponse
@@ -627,9 +628,14 @@ class Application(object):
 
     def run_test_instance(self, iss, tag):
         _port = self.assigned_ports.register_port(iss, tag)
-        args = [self.test_script, "-i", unquote_plus(iss), "-t",
-                unquote_plus(tag), "-p", str(_port), "-M", self.mako_dir,
-                "-f", self.flowdir]
+        
+        args = [self.test_script]
+        args.extend(["-i", shlex.quote(unquote_plus(iss))])
+        args.extend(["-t", shlex.quote(unquote_plus(tag))])        
+        args.extend(["-p", str(_port)])
+        args.extend(["-M", self.mako_dir])
+        args.extend(["-f", self.flowdir])
+
         if self.path2port:
             args.extend(["-m", self.path2port])
             ppmap = read_path2port_map(self.path2port)
@@ -662,10 +668,12 @@ class Application(object):
 
         # Now get it running
         args.append('&')
-        logger.info("Test tool command: {}".format(" ".join(args)))
-        # spawn independent process
-        os.system(" ".join(args))
+        cmd = " ".join(args)
+        logger.info("Test tool command: {}".format(cmd))
 
+        # spawn independent process
+        os.system(cmd)
+        
         pid = 0
         for i in range(0,10):
             time.sleep(1)

--- a/src/oidctest/tt/app.py
+++ b/src/oidctest/tt/app.py
@@ -2,6 +2,7 @@ import logging
 import os
 import subprocess
 import time
+import shlex
 from urllib.parse import unquote_plus
 
 from oic.utils.http_util import ServiceError
@@ -29,9 +30,14 @@ class Application(object):
 
     def run_test_instance(self, iss, tag):
         _port = self.assigned_ports.register_port(iss, tag)
-        args = [self.test_script, "-i", '"{}"'.format(unquote_plus(iss)), "-t",
-                '"{}"'.format(unquote_plus(tag)), "-p", str(_port), "-f",
-                self.flowdir, '-s']
+        
+        args = [self.test_script]
+        args.extend(["-i", shlex.quote(unquote_plus(iss))])
+        args.extend(["-t", shlex.quote(unquote_plus(tag))])        
+        args.extend(["-p", str(_port)])
+        args.extend(["-f", self.flowdir])
+        args.append("-s")
+        
         if self.path2port:
             args.extend(["-m", self.path2port])
             ppmap = read_path2port_map(self.path2port)
@@ -69,10 +75,11 @@ class Application(object):
 
         # Now get it running
         args.append('&')
-        logger.info("Test tool command: {}".format(" ".join(args)))
+        cmd = " ".join(args)
+        logger.info("Test tool command: {}".format(cmd))
 
         # spawn independent process, leaping blindly here
-        os.system(" ".join(args))
+        os.system(cmd)
 
         pid = 0
         for i in range(0, 10):


### PR DESCRIPTION
shell escape "iss" and "tag" values (provided by configuration) before
passing those values to os.system calls

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>