### PR TITLE
Issue #142. 

### DIFF
--- a/src/oidctest/op/func.py
+++ b/src/oidctest/op/func.py
@@ -601,10 +601,12 @@ def set_client_authn_method(oper, arg):
         _method = _entity.behaviour["token_endpoint_auth_method"]        
     except KeyError:
         try:
-            _method = _entity.provider_info[
-                "token_endpoint_auth_methods_supported"][0]
-            #generate a key error if client authn method is not supported by pyoidc
-            CLIENT_AUTHN_METHOD[_method]
+            if _entity.provider_info["token_endpoint_auth_methods_supported"] :
+                for sam in _entity.provider_info["token_endpoint_auth_methods_supported"]:
+                    if sam in CLIENT_AUTHN_METHOD:
+                        #use the first mutually supported method
+                        _method=sam
+                        break                
         except KeyError:  # Go with default
             _method = 'client_secret_basic'
     

--- a/test_tool/cp/test_op/flows/OP-ClientAuth-Basic-Dynamic.json
+++ b/test_tool/cp/test_op/flows/OP-ClientAuth-Basic-Dynamic.json
@@ -13,6 +13,11 @@
     },
     {
       "Registration": {
+        "check_support": {
+          "ERROR": {
+            "token_endpoint_auth_methods_supported": "client_secret_basic"
+          }
+        },
         "set_request_args": {
           "token_endpoint_auth_method": "client_secret_basic"
         }

--- a/test_tool/cp/test_op/flows/OP-ClientAuth-PrivateJWT.json
+++ b/test_tool/cp/test_op/flows/OP-ClientAuth-PrivateJWT.json
@@ -13,6 +13,11 @@
     },
     {
       "Registration": {
+        "check_support": {
+          "ERROR": {
+            "token_endpoint_auth_methods_supported": "private_key_jwt"
+          }
+        },
         "set_request_args": {
           "token_endpoint_auth_method": "private_key_jwt"
         }

--- a/test_tool/cp/test_op/flows/OP-ClientAuth-SecretJWT.json
+++ b/test_tool/cp/test_op/flows/OP-ClientAuth-SecretJWT.json
@@ -13,6 +13,11 @@
     },
     {
       "Registration": {
+        "check_support": {
+          "ERROR": {
+            "token_endpoint_auth_methods_supported": "client_secret_jwt"
+          }
+        },
         "set_request_args": {
           "token_endpoint_auth_method": "client_secret_jwt"
         }

--- a/test_tool/cp/test_op/flows/OP-ClientAuth-SecretPost-Dynamic.json
+++ b/test_tool/cp/test_op/flows/OP-ClientAuth-SecretPost-Dynamic.json
@@ -13,6 +13,11 @@
     },
     {
       "Registration": {
+        "check_support": {
+          "ERROR": {
+            "token_endpoint_auth_methods_supported": "client_secret_post"
+          }
+        },
         "set_request_args": {
           "token_endpoint_auth_method": "client_secret_post"
         }

--- a/tests/flows/OP-ClientAuth-Basic-Dynamic.json
+++ b/tests/flows/OP-ClientAuth-Basic-Dynamic.json
@@ -13,6 +13,11 @@
     },
     {
       "Registration": {
+        "check_support": {
+          "ERROR": {
+            "token_endpoint_auth_methods_supported": "client_secret_basic"
+          }
+        },
         "set_request_args": {
           "token_endpoint_auth_method": "client_secret_basic"
         }

--- a/tests/flows/OP-ClientAuth-PrivateJWT.json
+++ b/tests/flows/OP-ClientAuth-PrivateJWT.json
@@ -13,6 +13,11 @@
     },
     {
       "Registration": {
+        "check_support": {
+          "ERROR": {
+            "token_endpoint_auth_methods_supported": "private_key_jwt"
+          }
+        },
         "set_request_args": {
           "token_endpoint_auth_method": "private_key_jwt"
         }

--- a/tests/flows/OP-ClientAuth-SecretJWT.json
+++ b/tests/flows/OP-ClientAuth-SecretJWT.json
@@ -13,6 +13,11 @@
     },
     {
       "Registration": {
+        "check_support": {
+          "ERROR": {
+            "token_endpoint_auth_methods_supported": "client_secret_jwt"
+          }
+        },
         "set_request_args": {
           "token_endpoint_auth_method": "client_secret_jwt"
         }

--- a/tests/flows/OP-ClientAuth-SecretPost-Dynamic.json
+++ b/tests/flows/OP-ClientAuth-SecretPost-Dynamic.json
@@ -13,6 +13,11 @@
     },
     {
       "Registration": {
+        "check_support": {
+          "ERROR": {
+            "token_endpoint_auth_methods_supported": "client_secret_post"
+          }
+        },
         "set_request_args": {
           "token_endpoint_auth_method": "client_secret_post"
         }


### PR DESCRIPTION
I added checks to make sure that a mutually supported token endpoint authn method is used. Also updated some test flows and added checks to make sure that the required client authentication method is supported.

OP-ClientAuth-Basic-Static and OP-ClientAuth-Basic-Dynamic now return PARTIAL_RESULT with "No support for: token_endpoint_auth_methods_supported=client_secret_basic" error when client_secret_basic method is not supported. We should clarify if they should return a failure or not. 

How I tested it : 
- I used the node-oidc-provider
- I edited example/setttings.js to enable/disable specific client authentication methods and to create static clients. For example : 
```
...
module.exports.config = {
	tokenEndpointAuthMethods: ['private_key_jwt'],	//<<<add this line
	acrValues: ['urn:mace:incommon:iap:bronze'],
...
```
- I tested with both dynamically registered clients and static clients. 
- For example, enabled only client_secret_post in OP config and ran OP-ClientAuth-*-Dynamic tests. 

Before this change when the OP does not support client_secret_basic, many tests, for example OP-ClientAuth-Any-Dynamic fail with an error similar to the following : 
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/dist-packages/otest-0.7.3-py3.6.egg/otest/aus/tool.py", line 87, in run_flow
    resp = _oper()
  File "/usr/local/lib/python3.6/dist-packages/otest-0.7.3-py3.6.egg/otest/operation.py", line 105, in __call__
    res = self.run(*args, **kwargs)
  File "/usr/local/lib/python3.6/dist-packages/oidctest-0.7.5-py3.6.egg/oidctest/op/oper.py", line 133, in run
    **self.req_args)
  File "/usr/local/lib/python3.6/dist-packages/otest-0.7.3-py3.6.egg/otest/operation.py", line 171, in catch_exception_and_error
    res = func(**kwargs)
  File "/usr/local/lib/python3.6/dist-packages/oic-0.14.0-py3.6.egg/oic/oic/__init__.py", line 1386, in register
    return self.handle_registration_info(rsp)
  File "/usr/local/lib/python3.6/dist-packages/oic-0.14.0-py3.6.egg/oic/oic/__init__.py", line 1280, in handle_registration_info
    raise RegistrationError(resp.to_dict())
oic.exception.RegistrationError: {'error': 'invalid_client_metadata', 'error_description': 'token_endpoint_auth_method must be one of [private_key_jwt]'}
```
Before this change, an OP which only supports private_key_jwt method would not be able to pass conformance tests. 