### PR TITLE
oidctest Issue #7. 

### DIFF
--- a/src/oidctest/op/oper.py
+++ b/src/oidctest/op/oper.py
@@ -41,6 +41,7 @@ from otest.events import EV_REQUEST
 from otest.events import EV_RESPONSE
 from otest.events import OUTGOING
 from otest.prof_util import RESPONSE
+from oic.oauth2.exception import HttpError
 
 __author__ = 'roland'
 
@@ -217,11 +218,13 @@ class AccessToken(SyncPostRequest):
             EV_REQUEST,
             "op_args: {}, req_args: {}".format(self.op_args, self.req_args),
             direction=OUTGOING)
-
-        atr = self.catch_exception_and_error(
-            self.conv.entity.do_access_token_request,
-            request_args=self.req_args, **self.op_args)
-
+        try:
+            atr = self.catch_exception_and_error(
+                self.conv.entity.do_access_token_request,
+                request_args=self.req_args, **self.op_args)
+        except HttpError:
+            return None
+        
         if atr is None or isinstance(atr, ErrorResponse):
             return atr
 

--- a/test_tool/cp/test_op/flows/OP-OAuth-2nd-30s.json
+++ b/test_tool/cp/test_op/flows/OP-OAuth-2nd-30s.json
@@ -44,6 +44,7 @@
     }
   ],
   "assert": {
+    "check-http-error-response":{},
     "verify-response": {
       "response_cls": [
         "ErrorResponse"

--- a/test_tool/cp/test_op/flows/OP-OAuth-2nd.json
+++ b/test_tool/cp/test_op/flows/OP-OAuth-2nd.json
@@ -12,6 +12,7 @@
   "reference": "https://tools.ietf.org/html/rfc6749#section-5.2",
   "note": "This test should result in the OpenID Provider returning an error message.",
   "assert": {
+    "check-http-error-response":{},
     "verify-response": {
       "response_cls": [
         "ErrorResponse"

--- a/tests/flows/OP-OAuth-2nd-30s.json
+++ b/tests/flows/OP-OAuth-2nd-30s.json
@@ -44,6 +44,7 @@
   "reference": "http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.1",
   "note": "A 30 second delay is added between the first and the second use of the authorization code.",
   "assert": {
+    "check-http-error-response":{},  
     "verify-response": {
       "response_cls": [
         "ErrorResponse"

--- a/tests/flows/OP-OAuth-2nd.json
+++ b/tests/flows/OP-OAuth-2nd.json
@@ -11,6 +11,7 @@
   "desc": "Trying to use authorization code twice should result in an error",
   "reference": "http://tools.ietf.org/html/draft-ietf-oauth-v2-31#section-4.1",
   "assert": {
+    "check-http-error-response":{},  
     "verify-response": {
       "response_cls": [
         "ErrorResponse"


### PR DESCRIPTION
I added a try-except to prevent abrupt failures when response code is unexpected. Also added http response code checks to OP-OAuth-2nd and OP-OAuth-2nd-30s.

How to test it: 
- Run `docker exec -it docker_op_1 /bin/bash`
- Edit `./lib/helpers/errors.js`:  and change status code to 403, e.g:  
```super(403, 'invalid_grant');```
- Stop and restart (do not rebuild) docker_op_1. 
- Run https://op-test:60003/OP-OAuth-2nd and https://op-test:60003/OP-OAuth-2nd-30s

@rohe OP-OAuth-2nd-30s returns an error status while OP-OAuth-2nd returns a warning in case of an invalid_grant response. Should they be consistent? I can add another commit if we would like to make them consistent. Let me know if any additional changes are needed.  