### PR TITLE
Fix pyoidc version to 0.14.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests >= 2.0.0",
         'future',
         'CherryPy == 8.9.1',
-        'oic >= 0.14.0',
+        'oic == 0.14.0',
         'otest >= 0.7.3',
         'psutil',
         'cherrypy-cors >= 1.5'


### PR DESCRIPTION
pyoidc 0.15.0 breaks encrypted JWTs. 