### PR TITLE
oidctest issue 116

### DIFF
--- a/src/oidctest/op/client.py
+++ b/src/oidctest/op/client.py
@@ -79,15 +79,15 @@ class Client(oic.Client):
         elif resp.status_code == 401:
             try:                 
                 www_auth_header=resp.headers["WWW-Authenticate"]
-                res = ErrorResponse(error="invalid_token", 
+                res = ErrorResponse(error="invalid_token",
                                     error_description="Server returned 401 Unauthorized. WWW-Authenticate header:{}".format(www_auth_header))                
             except KeyError:
                 #no www-authenticate header. https://tools.ietf.org/html/rfc6750#section-3 reads: 
                 #the resource server MUST include the HTTP "WWW-Authenticate" response header field         
-                res = ErrorResponse(error="invalid_token", 
-                                    error_description="Server returned 401 Unauthorized without a WWW-Authenticate header which is required as per https://tools.ietf.org/html/rfc6750#section-3")                    
+                res = ErrorResponse(error="invalid_token",
+                                    error_description="Server returned 401 Unauthorized without a WWW-Authenticate header which is required as per https://tools.ietf.org/html/rfc6750#section-3")
             self.store_response(res, resp.text)
-            return res                 
+            return res
         elif 400 <= resp.status_code < 500:
             # the response text might be a OIDC message
             try:

--- a/src/oidctest/op/client.py
+++ b/src/oidctest/op/client.py
@@ -77,14 +77,17 @@ class Client(oic.Client):
         elif resp.status_code == 500:
             raise PyoidcError("ERROR: Something went wrong: %s" % resp.text)
         elif resp.status_code == 401:
-            try:
-                res = ErrorResponse().from_json(resp.text)
-            except Exception:
-                res = ErrorResponse().from_json('{"error":"401 Unauthorized", "error_description":"Server returned a 401 Unauthorized without a body"}')
-
+            try:                 
+                www_auth_header=resp.headers["WWW-Authenticate"]
+                res = ErrorResponse(error="invalid_token", 
+                                    error_description="Server returned 401 Unauthorized. WWW-Authenticate header:{}".format(www_auth_header))                
+            except KeyError:
+                #no www-authenticate header. https://tools.ietf.org/html/rfc6750#section-3 reads: 
+                #the resource server MUST include the HTTP "WWW-Authenticate" response header field         
+                res = ErrorResponse(error="invalid_token", 
+                                    error_description="Server returned 401 Unauthorized without a WWW-Authenticate header which is required as per https://tools.ietf.org/html/rfc6750#section-3")                    
             self.store_response(res, resp.text)
-            return res
-                 
+            return res                 
         elif 400 <= resp.status_code < 500:
             # the response text might be a OIDC message
             try:

--- a/src/oidctest/op/client.py
+++ b/src/oidctest/op/client.py
@@ -77,13 +77,13 @@ class Client(oic.Client):
         elif resp.status_code == 500:
             raise PyoidcError("ERROR: Something went wrong: %s" % resp.text)
         elif resp.status_code == 401:
-            try:                 
+            try:
                 www_auth_header=resp.headers["WWW-Authenticate"]
                 res = ErrorResponse(error="invalid_token",
-                                    error_description="Server returned 401 Unauthorized. WWW-Authenticate header:{}".format(www_auth_header))                
+                                    error_description="Server returned 401 Unauthorized. WWW-Authenticate header:{}".format(www_auth_header))
             except KeyError:
-                #no www-authenticate header. https://tools.ietf.org/html/rfc6750#section-3 reads: 
-                #the resource server MUST include the HTTP "WWW-Authenticate" response header field         
+                #no www-authenticate header. https://tools.ietf.org/html/rfc6750#section-3 reads:
+                #the resource server MUST include the HTTP "WWW-Authenticate" response header field
                 res = ErrorResponse(error="invalid_token",
                                     error_description="Server returned 401 Unauthorized without a WWW-Authenticate header which is required as per https://tools.ietf.org/html/rfc6750#section-3")
             self.store_response(res, resp.text)

--- a/src/oidctest/op/client.py
+++ b/src/oidctest/op/client.py
@@ -76,6 +76,15 @@ class Client(oic.Client):
                 sformat = "jwt"
         elif resp.status_code == 500:
             raise PyoidcError("ERROR: Something went wrong: %s" % resp.text)
+        elif resp.status_code == 401:
+            try:
+                res = ErrorResponse().from_json(resp.text)
+            except Exception:
+                res = ErrorResponse().from_json('{"error":"401 Unauthorized", "error_description":"Server returned a 401 Unauthorized without a body"}')
+
+            self.store_response(res, resp.text)
+            return res
+                 
         elif 400 <= resp.status_code < 500:
             # the response text might be a OIDC message
             try:


### PR DESCRIPTION
Prevent exceptions cause by 401 responses without a json body. 
WWW-Authenticate header is not parsed but added as a whole to error_description. 