### PR TITLE
address openid-certification/oidctest#144

### DIFF
--- a/test_tool/cp/test_op/flows/OP-nonce-NoReq-noncode.json
+++ b/test_tool/cp/test_op/flows/OP-nonce-NoReq-noncode.json
@@ -8,7 +8,7 @@
       "CIT"
     ]
   },
-  "desc": "Reject requests without nonce unless using the code flow",
+  "desc": "Reject requests without nonce unless using the 'code' or 'code token' flow",
   "sequence": [
     {
       "Webfinger": {
@@ -40,10 +40,9 @@
     "I",
     "IT",
     "CI",
-    "CT",
     "CIT"
   ],
-  "note": "This test should result in the OpenID Provider displaying an error message in your user agent. You should ignore the status of this test in the test tool, since it will be incomplete. You must submit a screen shot of the error shown as part of your certification application.",
+  "note": "There are two acceptable outcomes: (1) returning an error response to the RP or (2) returning an error message to the End-User. In case (2), you must submit a screen shot of the error shown as part of your certification application.",
   "assert": {
     "verify-response": {
       "response_cls": [


### PR DESCRIPTION
Change OP-nonce-NoReq-noncode to allow an error response returned from
the OP to the test suite without an intermediate screen displaying
(wrong) text.

- correct the note text about only the OP allowed to display an error
- the test suite also allows the OP to return "invalid_request" or
similar returned in a redirect
- remove CT from MTI (previously omitted)

Signed-off-by: Hans Zandbelt <hans.zandbelt@zmartzone.eu>