### PR TITLE
the previous patch apparently swapped the syntax between reg and auth

### DIFF
--- a/test_tool/cp/test_op/flows/OP-redirect_uri-Query-Mismatch.json
+++ b/test_tool/cp/test_op/flows/OP-redirect_uri-Query-Mismatch.json
@@ -13,7 +13,7 @@
     },
     {
       "Registration": {
-        "redirect_uri_with_query_component": {
+        "redirect_uris_with_query_component": {
           "foo": "bar"
         }
       }
@@ -21,7 +21,7 @@
     "Note",
     {
       "AsyncAuthn": {
-        "redirect_uris_with_query_component": {
+        "redirect_uri_with_query_component": {
           "bar": "foo"
         },
         "set_response_where": null


### PR DESCRIPTION
address openid-certification/oidctest#189